### PR TITLE
Add github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # - package-ecosystem: pip
+  #   directory: "/"
+  #   schedule:
+  #     interval: daily
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates once a week
+      interval: 'weekly'

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,44 @@
+name: link-checker
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 0 * * SUN' # Sunday “At 00:30”
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    if: github.repository == 'brian-rose/ClimateLaboratoryBook'
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@master
+        with:
+          channels: conda-forge
+          channel-priority: strict
+          activate-environment: climlab-courseware
+          auto-update-conda: false
+          python-version: 3.8
+          environment-file: environment.yml
+          mamba-version: '*'
+          use-mamba: true
+
+      # - name: Disable notebook execution
+      #   shell: python
+      #   run: |
+      #     import yaml
+      #     with open('_config.yml') as f:
+      #       data = yaml.safe_load(f)
+      #     data['execute']['execute_notebooks'] = 'off'
+      #     with open('_config.yml', 'w') as f:
+      #       yaml.dump(data, f)
+      - name: Check external links
+        run: |
+          jupyter-book build --builder linkcheck .

--- a/_config.yml
+++ b/_config.yml
@@ -72,4 +72,6 @@ repository:
 # Advanced and power-user settings
 sphinx:
   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
-  config                    :   # key-value pairs to directly over-ride the Sphinx configuration
+  local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
+  # We are ignoring the link to the JupyterHub because of an issue with the certificate
+  config                    :   {linkcheck_ignore: https://lore.atmos.albany.edu:8000} # key-value pairs to directly over-ride the Sphinx configuration

--- a/_config.yml
+++ b/_config.yml
@@ -74,4 +74,5 @@ sphinx:
   extra_extensions          :   # A list of extra extensions to load by Sphinx (added to those already used by JB).
   local_extensions          :   # A list of local extensions to load by sphinx specified by "name: path" items
   # We are ignoring the link to the JupyterHub because of an issue with the certificate
-  config                    :   {linkcheck_ignore: https://lore.atmos.albany.edu:8000} # key-value pairs to directly over-ride the Sphinx configuration
+  config                    :   # key-value pairs to directly over-ride the Sphinx configuration
+    linkcheck_ignore        : https://lore.atmos.albany.edu:8000

--- a/how-to.md
+++ b/how-to.md
@@ -40,14 +40,6 @@ This should bring you to a login screen. Use your standard UAlbany netid and pas
 
 *UAlbany users, please let me know if things don't seem to be working correctly.*
 
-### TEMPORARY TEST
-
-Link to some other JupyterHub instances:
-- <https://reed.atmos.albany.edu:8000>
-- <https://ash.atmos.albany.edu:8000>
-- <https://rainier.atmos.albany.edu:8000>
-
-
 ## Public users: interact through a cloud-based Binder service
 
 *(currently broken -- working on it)*

--- a/how-to.md
+++ b/how-to.md
@@ -40,6 +40,14 @@ This should bring you to a login screen. Use your standard UAlbany netid and pas
 
 *UAlbany users, please let me know if things don't seem to be working correctly.*
 
+### TEMPORARY TEST
+
+Link to some other JupyterHub instances:
+- <https://reed.atmos.albany.edu:8000>
+- <https://ash.atmos.albany.edu:8000>
+- <https://rainier.atmos.albany.edu:8000>
+
+
 ## Public users: interact through a cloud-based Binder service
 
 *(currently broken -- working on it)*


### PR DESCRIPTION
Switch on GitHub Actions to do two simple things:
- Run a weekly cron job to check links in the built built
- Run dependabot to keep the GitHub Actions up to date

The link checker should also run on pull requests.