### PR TITLE
Finish deploy actions business

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # The Climate Laboratory
 
 [![DOI](https://zenodo.org/badge/231609808.svg)](https://zenodo.org/badge/latestdoi/231609808)
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/deploy-book/main?logo=github&style=for-the-badge)
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/link-checker/main?logo=github&style=for-the-badge)
+<!-- ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/deploy-book/main?logo=github&style=for-the-badge)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/link-checker/main?logo=github&style=for-the-badge) -->
+![Deploy Book](https://github.com/github/docs/actions/workflows/deploy.yaml/badge.svg)
+![Link Checker](https://github.com/github/docs/actions/workflows/link-checker.yaml/badge.svg)
 
 ***A hands-on approach to climate physics and climate modeling***
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # The Climate Laboratory
 
 [![DOI](https://zenodo.org/badge/231609808.svg)](https://zenodo.org/badge/latestdoi/231609808)
-<!-- ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/deploy-book/main?logo=github&style=for-the-badge)
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/link-checker/main?logo=github&style=for-the-badge) -->
 ![Deploy Book](https://github.com/brian-rose/ClimateLaboratoryBook/actions/workflows/deploy.yaml/badge.svg)
 ![Link Checker](https://github.com/brian-rose/ClimateLaboratoryBook/actions/workflows/link-checker.yaml/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ Anyone is welcome to suggest edits or improvements by opening pull requests on t
 
 ## How is the book published
 
-[The book][book] is just the rendered html that results from running `jupyter-book build`. Currently I use the [ghp-import][ghp-import] tool to copy the built html to the `gh-pages` branch on [github][repo].
-
-See the [JupyterBook docs][jbook-publish] for more info on this.
+[The book][book] is just the rendered html that results from running `jupyter-book build`. A new build is triggered on GitHub Actions whenever the sources are updated on the [github repository][repo], and the successful build is deployed to the `gh-pages` branch of the repo.
 
 
 [brian]: http://www.atmos.albany.edu/facstaff/brose/index.html

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![DOI](https://zenodo.org/badge/231609808.svg)](https://zenodo.org/badge/latestdoi/231609808)
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/deploy-book/main?logo=github&style=for-the-badge)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/link-checker/main?logo=github&style=for-the-badge)
 
 ***A hands-on approach to climate physics and climate modeling***
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![DOI](https://zenodo.org/badge/231609808.svg)](https://zenodo.org/badge/latestdoi/231609808)
 <!-- ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/deploy-book/main?logo=github&style=for-the-badge)
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/link-checker/main?logo=github&style=for-the-badge) -->
-![Deploy Book](https://github.com/github/docs/actions/workflows/deploy.yaml/badge.svg)
-![Link Checker](https://github.com/github/docs/actions/workflows/link-checker.yaml/badge.svg)
+![Deploy Book](https://github.com/brian-rose/ClimateLaboratoryBook/actions/workflows/deploy.yaml/badge.svg)
+![Link Checker](https://github.com/brian-rose/ClimateLaboratoryBook/actions/workflows/link-checker.yaml/badge.svg)
 
 ***A hands-on approach to climate physics and climate modeling***
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Climate Laboratory
 
 [![DOI](https://zenodo.org/badge/231609808.svg)](https://zenodo.org/badge/latestdoi/231609808)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/brian-rose/ClimateLaboratoryBook/deploy-book/main?logo=github&style=for-the-badge)
 
 ***A hands-on approach to climate physics and climate modeling***
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,3 @@ dependencies:
   - netcdf4
   - nc-time-axis
   - jupyter-book  # needed to rebuild the book from source
-  - pip
-  - pip:
-    # works for regular pip packages
-    - ghp-import  # used to automatically push the built book to github pages

--- a/how-to.md
+++ b/how-to.md
@@ -1,7 +1,5 @@
 # How to use this book
 
-*under construction*
-
 I wrote this book with a strong emphasis on *reproducibility* of the content.
 For example, most of the figures in the notes are generated interactively,
 often using data pulled from public servers. This means that readers are able
@@ -41,8 +39,6 @@ This should bring you to a login screen. Use your standard UAlbany netid and pas
 *UAlbany users, please let me know if things don't seem to be working correctly.*
 
 ## Public users: interact through a cloud-based Binder service
-
-*(currently broken -- working on it)*
 
 This will work well for many of the simple examples,
 but some of the notes require more computational resources.

--- a/publish
+++ b/publish
@@ -1,1 +1,0 @@
-ghp-import -n -p -f _build/html


### PR DESCRIPTION
Copied from #25, needed to merge that before everything was done in order to trigger the right actions.

- [x]  Use a minimal jupyter-book environment for the link checking step
- [ ]   Use same minimal environment to build book previews, deploy to netlify
- [x]   Build and deploy to gh-pages upon push to main branch
- [x]   Put useful status badges on README page
- [x]   Update build instructions