### PR TITLE
Try caching the mamba environment

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -2,6 +2,9 @@ name: build-book
 on:
   pull_request:
 
+env:
+  CACHE_NUMBER: 0  # increase to reset cache manually
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
@@ -10,19 +13,32 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup conda environment
-        uses: conda-incubator/setup-miniconda@master
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          channels: conda-forge
-          channel-priority: strict
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: book-render
-          auto-update-conda: false
-          environment-file: render-environment.yml
-          mamba-version: '*'
           use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: /usr/share/miniconda3/envs/my-env
+          key: linux-64-conda-${{ hashFiles('book-render.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mamba env update -n book-render -f render-environment.yml
+
       - name: Build the book
         run: |
           jupyter-book build .
+
       - name: Zip the book
         run: |
           set -x
@@ -31,6 +47,7 @@ jobs:
               rm -rf book.zip
           fi
           zip -r book.zip _build/html
+
       - name: Upload zipped book artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: /usr/share/miniconda3/envs/my-env
+          path: /usr/share/miniconda3/envs/book-render
           key: linux-64-conda-${{ hashFiles('book-render.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
 

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -20,16 +20,27 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v3
-      - name: Set up conda environment
-        uses: conda-incubator/setup-miniconda@master
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          channels: conda-forge
-          channel-priority: strict
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: book-render
-          auto-update-conda: false
-          environment-file: render-environment.yml
-          mamba-version: '*'
           use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: /usr/share/miniconda3/envs/book-render
+          key: linux-64-conda-${{ hashFiles('book-render.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mamba env update -n book-render -f render-environment.yml
 
       # Build the book
       - name: Build the book

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -18,16 +18,27 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v3
-      - name: Set up conda environment
-        uses: conda-incubator/setup-miniconda@master
+      
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          channels: conda-forge
-          channel-priority: strict
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: book-render
-          auto-update-conda: false
-          environment-file: render-environment.yml
-          mamba-version: '*'
           use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: /usr/share/miniconda3/envs/book-render
+          key: linux-64-conda-${{ hashFiles('book-render.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mamba env update -n book-render -f render-environment.yml
 
       # - name: Disable notebook execution
       #   shell: python

--- a/home.md
+++ b/home.md
@@ -4,6 +4,8 @@
 
 **By [Brian E. J. Rose][brian], University at Albany**
 
+**IGNORE MY TEXT**
+
 This will evolve into the textbook for both
 [ENV 415: Climate Laboratory][env415] and [ATM 623: Climate Modeling][atm623]
 at the [University at Albany][ualbany].

--- a/home.md
+++ b/home.md
@@ -4,8 +4,6 @@
 
 **By [Brian E. J. Rose][brian], University at Albany**
 
-**IGNORE MY TEXT**
-
 This will evolve into the textbook for both
 [ENV 415: Climate Laboratory][env415] and [ATM 623: Climate Modeling][atm623]
 at the [University at Albany][ualbany].


### PR DESCRIPTION
Here's a strategy to speed up preview deployment: create the conda environment (using mamba) once, and cache it for later reuse.

The idea is that the cache is date-stamped, and will get rebuilt if the date changes OR the environment file changes.

Following this tutorial: https://dev.to/epassaro/caching-anaconda-environments-in-github-actions-5hde