### PR TITLE
Fix environment name

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: new-climlab-courseware
+name: climlab-courseware
 channels:
   - conda-forge
 dependencies:

--- a/render-environment.yml
+++ b/render-environment.yml
@@ -4,5 +4,5 @@ name: book-render
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python
   - jupyter-book  # needed to rebuild the book from source


### PR DESCRIPTION
Accidentally cut a release with a temporary placeholder name in the environment.yml file. This PR fixes that, and I will cut another release.